### PR TITLE
Add missing print statement

### DIFF
--- a/manuscript/1.0file.md
+++ b/manuscript/1.0file.md
@@ -112,10 +112,10 @@ Explanation:
 `$` is used to match end of line. `/\.md$/` matches with all the lines where the file ends with `.md`. Here, we needed to escape the `.` because it carried special significance. That's why, we added a backslash before the `.`.
 
 * BEGIN, BODY, END
-        
-        ls -l | awk 'BEGIN {"This is BEGIN"} { print "BODY", $0 } END {print "This is END"}'
 
-Explanation: There are three blocks in awk, BEGIN, BODY and END. When you execute the above statement, you'll see output like 
+        ls -l | awk 'BEGIN { print "This is BEGIN"} { print "BODY", $0 } END {print "This is END"}'
+
+Explanation: There are three blocks in awk, BEGIN, BODY and END. When you execute the above statement, you'll see output like
 
         This is BEGIN
         BODY total 4256


### PR DESCRIPTION
I really enjoyed learning from this! I

 found one small typo:

`ls -l | awk 'BEGIN {"This is BEGIN"} { print "BODY", $0 } END {print "This is END"}` results in:

```
awk: illegal statement
 source line number 1
```

whereas:

` ls -l | awk 'BEGIN { print "This is BEGIN"} { print "BODY", $0 } END {print "This is END"}'`
results in
```
This is BEGIN
BODY total 16
BODY -rw-r--r--   1 thomas  staff  2389 Mar  2 09:47 README.md
BODY -rw-r--r--   1 thomas  staff   130 Mar  2 09:47 SUMMARY.md
BODY drwxr-xr-x  31 thomas  staff   992 Mar  2 09:47 code
BODY drwxr-xr-x   7 thomas  staff   224 Mar  2 09:47 manuscript
This is END
```